### PR TITLE
Optional transcript

### DIFF
--- a/skills/true-wealth-hiring-working-student/SKILL.md
+++ b/skills/true-wealth-hiring-working-student/SKILL.md
@@ -154,7 +154,7 @@ Handle the response as follows:
 
 - If the user provides a URL, do a light sanity check: starts with `http`, 
   or with `github.com` or `linkedin.com`, is not a shortened URL, 
-  is not an overly long URL (>50 characters). If the check fails, gently ask 
+  is not an overly long URL (>100 characters). If the check fails, gently ask 
   them to change the input or type **skip**.
 - If the user says **skip**, says they'll send a CV by email, or otherwise
   declines, store an empty string. Do **not** pressure them.

--- a/skills/true-wealth-hiring-working-student/SKILL.md
+++ b/skills/true-wealth-hiring-working-student/SKILL.md
@@ -38,8 +38,10 @@ or any affirmative):
 > this may include Anthropic's standard data usage policies (e.g., conversations
 > on free plans may be reviewed to improve models, while Pro and Team plans offer
 > additional privacy protections). Please review Anthropic's [Privacy Policy](https://www.anthropic.com/privacy)
-> if you have questions. Your application data will be submitted to
-> True Wealth's CRM platform at Attio over HTTPS, and will be hosted in the UK.
+> if you have questions. Your application data — the structured fields you
+> provide, and optionally a transcript of this conversation if you choose to
+> include it — will be submitted to True Wealth's CRM platform at Attio over
+> HTTPS, and will be hosted in the UK.
 > Don't want to use this tool? Apply by email at `jobs@truewealth.ch` — you
 > will not be disadvantaged for choosing that route.
 >
@@ -164,14 +166,52 @@ applicant.profile_url = "<url>" | ""
 
 ---
 
+## Step 5b — Optional conversation transcript
+
+Ask the user, in a warm tone, whether they would like to include a transcript
+of this conversation alongside the structured fields. Frame it as fully
+optional and explain the benefit briefly: it gives the recruiting team context
+the structured form alone cannot capture.
+
+Example phrasing:
+
+> "One last optional thing: would you like to include a transcript of our
+> conversation with your application? It can give the recruiting team a bit
+> more context than the form alone. Type **yes** to include it, or **no** to
+> skip."
+
+If the user agrees, compose the transcript yourself from this conversation's
+context:
+
+- Format as alternating `Claude:` / `Applicant:` blocks, in chronological
+  order.
+- Include the application Q&A only — not your internal reasoning, tool calls,
+  or the disclaimer recital.
+- **Redact sensitive content.** If the applicant volunteered health, religious
+  or political views, trade-union membership, biometric data, criminal-record
+  information, or third-party personal data without consent, replace the
+  affected lines with `[redacted — sensitive personal data]`. Do this
+  silently; do not re-prompt the user.
+- Keep the transcript under ~80 KB. If the conversation is longer, summarize
+  earlier portions and quote the later, more relevant exchanges verbatim.
+
+If the user declines, set the transcript to an empty string and proceed.
+
+Store:
+```
+applicant.transcript = "<text>" | ""
+```
+
+---
+
 ## Step 6 — Submit
 
 Once all fields are collected, submit via the Bash tool:
 
 - Run: `bash "${CLAUDE_PLUGIN_ROOT}/skills/true-wealth-hiring-working-student/submit.sh"`
 - Pass the collected values as arguments:
-  `--name "<name>" --email "<email>" --most_recent_degree "<degree string>" --motivation "<motivation>" --swiss_work_permit true|false --profile_url "<url or empty>"`
-- Always include all six flags. `--motivation` and `--profile_url` may be empty strings; the other four must be non-empty (the script enforces this).
+  `--name "<name>" --email "<email>" --most_recent_degree "<degree string>" --motivation "<motivation>" --swiss_work_permit true|false --profile_url "<url or empty>" --transcript "<transcript or empty>"`
+- Always include all seven flags. `--motivation`, `--profile_url`, and `--transcript` may be empty strings; the other four must be non-empty (the script enforces this).
 - `--swiss_work_permit` must be the literal `true` or `false`.
 
 Example:
@@ -183,7 +223,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/true-wealth-hiring-working-student/submit.sh"
   --most_recent_degree "University of Neuchatel, BSc in Finance, 3" \
   --motivation "Interested in wealth-tech and Swiss fintech." \
   --swiss_work_permit true \
-  --profile_url "https://www.linkedin.com/in/jane-doe"
+  --profile_url "https://www.linkedin.com/in/jane-doe" \
+  --transcript "Claude: Welcome! ...\nApplicant: Hi, ..."
 ```
 
 If the script exits non-zero, do **not** show the Step 7 confirmation — follow the Error handling section below instead.

--- a/skills/true-wealth-hiring-working-student/submit.sh
+++ b/skills/true-wealth-hiring-working-student/submit.sh
@@ -12,6 +12,7 @@ most_recent_degree=""
 motivation=""
 swiss_work_permit=""
 profile_url=""
+transcript=""
 
 die() { printf 'Error: %s\n' "$1" >&2; exit 1; }
 
@@ -23,6 +24,7 @@ while [ $# -gt 0 ]; do
         --motivation)          motivation=$2;          shift 2 ;;
         --swiss_work_permit)   swiss_work_permit=$2;   shift 2 ;;
         --profile_url)        profile_url=$2;        shift 2 ;;
+        --transcript)          transcript=$2;          shift 2 ;;
         *) die "unknown argument: $1" ;;
     esac
 done
@@ -37,6 +39,11 @@ case "$swiss_work_permit" in
     *) die "--swiss_work_permit must be 'true' or 'false' (got: $swiss_work_permit)" ;;
 esac
 
+TRANSCRIPT_MAX=102400
+if [ "${#transcript}" -gt "$TRANSCRIPT_MAX" ]; then
+    transcript="${transcript:0:$TRANSCRIPT_MAX}"$'\n\n[transcript truncated at 100KB]'
+fi
+
 # JSON-escape a string for safe embedding in the payload.
 json_escape() {
     local s=$1
@@ -48,13 +55,19 @@ json_escape() {
     printf '%s' "$s"
 }
 
-payload=$(printf '{"name":"%s","email":"%s","most_recent_degree":"%s","motivation":"%s","swiss_work_permit":%s,"profile_url":"%s"}' \
+payload=$(printf '{"name":"%s","email":"%s","most_recent_degree":"%s","motivation":"%s","swiss_work_permit":%s,"profile_url":"%s","transcript":"%s"}' \
     "$(json_escape "$name")" \
     "$(json_escape "$email")" \
     "$(json_escape "$most_recent_degree")" \
     "$(json_escape "$motivation")" \
     "$swiss_work_permit" \
-    "$(json_escape "$profile_url")")
+    "$(json_escape "$profile_url")" \
+    "$(json_escape "$transcript")")
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+    printf '%s\n' "$payload"
+    exit 0
+fi
 
 resp_file=$(mktemp -t tw_apply_resp.XXXXXX) || die "could not create temp file."
 trap 'rm -f "$resp_file"' EXIT


### PR DESCRIPTION
The README states that an applicant can "optionally" include "the full conversation transcript" with their submission, but `submit.sh` only POSTs the six structured fields — there's no path for a transcript to reach Attio. This PR adds that path.

### Changes

- `submit.sh`: optional `--transcript` flag, JSON-escaped through the existing helper, 100 KB hard cap with a truncation marker, and a `DRY_RUN=1` env shortcut for local payload inspection. Existing six-argument invocations are unchanged.
- `SKILL.md`: new **Step 5b** that asks the applicant whether to include a transcript and instructs Claude on how to compose and redact it. Updated Step 0 disclaimer and Step 6 example.
- **Drive-by:** raised the `profile_url` length cap from 50 to 100 characters. The 28-char `https://www.linkedin.com/in/` prefix leaves only 22 chars for the handle under the current cap, which overflows on common LinkedIn-disambiguated handles and multi-part names. 

### Testing

End-to-end smoke test against the production webhook returned HTTP 202 and triggered the confirmation email. 
