### PR TITLE
README: lead with the no-terminal apply TL;DR

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ online wealth management.
 Applications are handled conversationally via [Claude Code](https://claude.ai/code). 
 Please read the Privacy & Data Handling section for details.
 
+> [!TIP]
+> **Fastest way to apply — no terminal or git knowledge needed.**
+> Open [Claude Code](https://claude.ai/code) (the desktop app is enough) and paste:
+>
+> ```
+> Please clone https://github.com/true-wealth/true-wealth-jobs, read the CLAUDE.md
+> file inside it, and follow its instructions to help me apply to True Wealth.
+> ```
+>
+> Claude does the rest — you just answer its questions in the chat.
+
 
 ---
 


### PR DESCRIPTION
Adds a GitHub TIP callout at the very top of the README with the copy-paste prompt for applying without a terminal. Reason: assistants and skim-readers summarizing the repo keep the first prominent instruction - previously that was the manual git clone route.

Docs only, no flow or script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)