### PR TITLE
Privacy section: remove ambiguity about what the submission includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Don't include third-party data without consent. Avoid mentioning identifiable co
 
 ### When you submit the summary
 
-Once you submit, True Wealth becomes the data controller for the data you send: the structured application fields, the application write-up you review and approve during the conversation, and your CV if you choose to attach one. The conversation itself is not transmitted — only the write-up you approved.
+Once you submit, True Wealth becomes the data controller for the data you send: the structured application fields, the application write-up you review and approve during the conversation, and your CV if you choose to attach one. The conversation itself is never transmitted; of its content, only the write-up you approved is included in the submission.
 
 The submitted data is stored in *Attio CRM* (hosted in the UK under a Data Processing Agreement with Standard Contractual Clauses in place) and in *BambooHR*, our applicant tracking system. It may be combined with information from our standard recruiting process (e.g. an LLM-assisted CV ranking via BambooHR — see our privacy policy for details).
 


### PR DESCRIPTION
Follow-up to the Copilot note on #6: the closing sentence could be read as only the write-up being transmitted, contradicting the enumeration before it (fields, write-up, CV). Now reads: the conversation is never transmitted; of its content, only the approved write-up is included in the submission.

Docs only, one sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)