### PR TITLE
Plausibility-check phone numbers on the client side

### DIFF
--- a/skills/apply/SKILL.md
+++ b/skills/apply/SKILL.md
@@ -217,6 +217,16 @@ message, conversationally:
      becomes `+4179…`).
    - Confirm the normalized number with the candidate before storing it. It must
      match `+` followed by 7–15 digits; `submit.sh` rejects anything else.
+   - **Plausibility-check the normalized number against the country's numbering
+     plan**, using your knowledge: does the country code exist, and do the
+     remaining digits have a plausible length and leading digit for that
+     country? (E.g. a Swiss number is `+41` plus 9 digits never starting with
+     0; after `+7`, numbers have 10 digits and never start with 0; Italian
+     numbers, by contrast, do keep their leading 0.) This applies equally to
+     numbers extracted from a CV or LinkedIn profile. If the number looks
+     implausible, don't argue — say what looks off and ask the candidate to
+     double-check, because the recruiting system rejects invalid numbers and
+     the application would fail to process.
 4. **Postal address** — street + number, postal code and city, country (suggest
    "Switzerland" as a likely default, but let them answer freely).
 5. **Swiss work permit** — "Do you currently hold a valid Swiss work permit?

--- a/skills/apply/submit.sh
+++ b/skills/apply/submit.sh
@@ -104,6 +104,7 @@ case "$phone" in
 esac
 case "$phone_digits" in
     ''|*[!0-9]*) die "--phone must be '+' followed by digits only, no spaces or separators (got: $phone)" ;;
+    0*) die "--phone cannot start with '+0' - no country code begins with 0 (got: $phone)" ;;
 esac
 if [ "${#phone_digits}" -lt 7 ] || [ "${#phone_digits}" -gt 15 ]; then
     die "--phone must contain 7-15 digits after the '+' (got: $phone)"


### PR DESCRIPTION
A live mock test used +70810810880, which passed the client-side format check (+ and 7-15 digits) but is plan-invalid: after +7, national numbers have 10 digits and never start with 0. The CRM-side validation correctly rejected it and the processing workflow stopped.

Client side now catches more of this earlier:

- submit.sh rejects +0... (no country code begins with 0)
- the application skill instructs Claude to plausibility-check the normalized number against the countrys numbering plan - for manually entered and CV-extracted numbers alike - and to ask the candidate to double-check when something looks off

Full numbering-plan validation stays server-side; this is about failing early with a helpful message instead of late in the CRM workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)