### PR TITLE
Link the values mention to truewealth.ch/culture

### DIFF
--- a/skills/true-wealth-hiring-digital-marketing-manager/job_description.md
+++ b/skills/true-wealth-hiring-digital-marketing-manager/job_description.md
@@ -69,7 +69,7 @@ contribute to reshaping how people in Switzerland approach investing. You will s
 well-oiled marketing setup with real budgets, real traction, and a team that wants
 you to succeed from day one. We work with flexible hours from a modern office in
 Zürich Binz, with room for home office alongside a mostly-in-office week. Our
-values: [truewealth.ch/en/our-values](https://www.truewealth.ch/en/our-values).
+values: [truewealth.ch/culture](https://www.truewealth.ch/culture).
 
 ---
 


### PR DESCRIPTION
Replaces the /en/our-values link in the live job description with https://www.truewealth.ch/culture (verified live). The parked vacancies on vacancies-staged received the same change.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)