### PR TITLE
Allow the submission script to run in all permission modes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash skills/apply/submit.sh:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-.claude/
+# Local Claude Code state stays untracked, but the shared project settings
+# (permission allowlist for the application flow) ship with the repo.
+.claude/*
+!.claude/settings.json
 .vs/


### PR DESCRIPTION
A test application with Claude Code in auto mode was blocked at the final step: the sandbox denies the webhook POST in submit.sh. This ships a project-level permission rule - Bash(bash skills/apply/submit.sh:*) - in .claude/settings.json so the submission runs in any permission mode, while everything else keeps its normal guardrails. The .gitignore now ignores .claude/* except settings.json.

Note the scope: the rule only helps candidates whose session was started inside the repository folder (project settings load from the session working directory). Candidates who have Claude clone the repo mid-session still see one permission prompt at submission - acceptable, since the skill announces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)