### PR TITLE
Formal-address grammar and provider-neutral privacy note

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ runs a short script that submits your application directly to True Wealth over
 HTTPS.
 
 Not a Claude user? The flow is plain git, bash, and one HTTPS request — any AI
-assistant that can execute local commands can drive it the same way.
+assistant that can execute local commands can drive it the same way. Note that
+the privacy description below is written for Claude: if you use another
+assistant, your conversation is processed by that provider under its own terms
+instead of Anthropic's.
 
 Prefer email? Send your CV to **jobs@truewealth.ch** — you will not be disadvantaged
 for choosing that route.

--- a/skills/apply/SKILL.md
+++ b/skills/apply/SKILL.md
@@ -73,9 +73,11 @@ language of the conversation so far** and wait for the user to acknowledge it
 in their language). Use the German, French, Italian, or Rumantsch Grischun
 version below when the conversation is in that language; **for any other
 language, default to the English version.** The only permitted adaptation: if
-the candidate has established formal address (Sie/vous/Lei), adjust the
-informal pronouns in the German/Italian versions accordingly — change nothing
-else.
+the candidate has established formal address (Sie/vous/Lei), convert the
+German/Italian versions from informal to formal address — pronouns,
+possessives, and the verb forms this grammatically requires (e.g. "die du
+machst" → "die Sie machen", "dein Abo" → "Ihr Abo") — changing nothing in
+content or wording beyond that.
 
 **English (default):**
 


### PR DESCRIPTION
Addresses the two Copilot comments on the merged #12:

- The disclaimer adaptation rule now explicitly permits the verb and possessive inflections that switching to formal address grammatically requires (die du machst -> die Sie machen), keeping everything else verbatim.
- The README tool-agnostic note now says that with a non-Claude assistant, the conversation is processed by that provider under its own terms - the Anthropic-specific privacy description does not transfer.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)