### PR TITLE
Wording: French disclaimer needs no adaptation; provider terms may differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ HTTPS.
 
 Not a Claude user? The flow is plain git, bash, and one HTTPS request — any AI
 assistant that can execute local commands can drive it the same way. Note that
-the privacy description below is written for Claude: if you use another
-assistant, your conversation is processed by that provider under its own terms
-instead of Anthropic's.
+the privacy description below is written for Claude: with another assistant,
+your conversation is handled under that provider's terms, which may differ
+from Anthropic's.
 
 Prefer email? Send your CV to **jobs@truewealth.ch** — you will not be disadvantaged
 for choosing that route.

--- a/skills/apply/SKILL.md
+++ b/skills/apply/SKILL.md
@@ -73,11 +73,11 @@ language of the conversation so far** and wait for the user to acknowledge it
 in their language). Use the German, French, Italian, or Rumantsch Grischun
 version below when the conversation is in that language; **for any other
 language, default to the English version.** The only permitted adaptation: if
-the candidate has established formal address (Sie/vous/Lei), convert the
-German/Italian versions from informal to formal address — pronouns,
-possessives, and the verb forms this grammatically requires (e.g. "die du
-machst" → "die Sie machen", "dein Abo" → "Ihr Abo") — changing nothing in
-content or wording beyond that.
+the candidate has established formal address, convert the German or Italian
+version from informal to formal — pronouns, possessives, and the verb forms
+this grammatically requires (e.g. "die du machst" → "die Sie machen", "dein
+Abo" → "Ihr Abo") — changing nothing in content or wording beyond that. The
+French version is already in formal address and needs no adaptation.
 
 **English (default):**
 


### PR DESCRIPTION
Two post-merge Copilot notes on #13, both wording-only:

- The formal-address rule no longer lists vous (the French version is already formal and needs no conversion; the rule applies to German/Italian only, now stated explicitly).
- The non-Claude-assistant note now says the providers terms "may differ from Anthropics" instead of asserting they are never Anthropics (some third-party tools route to Anthropic models).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)