### PR TITLE
Add rebuild trigger for truewealth.ch/jobs

### DIFF
--- a/.github/workflows/rebuild-jobs-page.yml
+++ b/.github/workflows/rebuild-jobs-page.yml
@@ -1,0 +1,26 @@
+name: Rebuild truewealth.ch/jobs
+
+# jobs.json is fetched at build time by truewealth.ch (see lib/jobs/jobsFeed.ts there), so a
+# change here only reaches the page once that site rebuilds. This triggers that rebuild
+# immediately whenever jobs.json changes, so a filled role stops advertising promptly.
+on:
+  push:
+    branches: [master]
+    paths:
+      - jobs.json
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call the Vercel deploy hook for truewealth.ch
+        run: |
+          if [ -z "${{ secrets.TRUEWEALTH_CH_DEPLOY_HOOK_URL }}" ]; then
+            echo "::error::TRUEWEALTH_CH_DEPLOY_HOOK_URL secret is not set. Create a Deploy Hook for the truewealth-ch Vercel project (Settings > Git > Deploy Hooks, Production branch) and add its URL as a secret under that name."
+            exit 1
+          fi
+          curl -fsS -X POST "${{ secrets.TRUEWEALTH_CH_DEPLOY_HOOK_URL }}"

--- a/.github/workflows/rebuild-jobs-page.yml
+++ b/.github/workflows/rebuild-jobs-page.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+# Only one rebuild is ever useful at a time; a rapid add-then-remove in jobs.json should
+# collapse to a single deploy for whatever landed last, not queue redundant Vercel builds.
+concurrency:
+  group: rebuild-jobs-page
+  cancel-in-progress: true
+
 jobs:
   trigger-deploy:
     runs-on: ubuntu-latest
@@ -23,4 +29,4 @@ jobs:
             echo "::error::TRUEWEALTH_CH_DEPLOY_HOOK_URL secret is not set. Create a Deploy Hook for the truewealth-ch Vercel project (Settings > Git > Deploy Hooks, Production branch) and add its URL as a secret under that name."
             exit 1
           fi
-          curl -fsS -X POST "${{ secrets.TRUEWEALTH_CH_DEPLOY_HOOK_URL }}"
+          curl -fsS --max-time 30 --retry 3 --retry-delay 5 -X POST "${{ secrets.TRUEWEALTH_CH_DEPLOY_HOOK_URL }}"


### PR DESCRIPTION
## Summary

`truewealth.ch` fetches `jobs.json` at build time (see `lib/jobs/jobsFeed.ts` there), so removing a filled role from this file doesn't reach the live page until that site rebuilds. This adds a GitHub Actions workflow that calls the `truewealth-ch` Vercel project's deploy hook on every push to `master` that touches `jobs.json`, so a filled role stops advertising promptly.

## Changes

- `.github/workflows/rebuild-jobs-page.yml`: triggers on `push` (scoped to `jobs.json` changes on `master`) and `workflow_dispatch` for manual runs. Guards against a missing secret with a clear error before curling.

## Requirements

- A `TRUEWEALTH_CH_DEPLOY_HOOK_URL` repo secret pointing at a Vercel Deploy Hook for the `truewealth-ch` project's production branch. This has already been added to repo settings.

## Notes

`workflow_dispatch` can't be exercised until this workflow exists on the default branch (GitHub doesn't register a workflow for manual dispatch from a feature branch), so it hasn't been live-tested yet. Happy to trigger a manual run right after merge to confirm the deploy hook fires correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJLfQoRDknGHuF1dBG5kPP)_